### PR TITLE
Fix sales report and add item specifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -447,7 +447,11 @@ def sales_report():
     product_search = request.args.get('product_search')
     
     # Build query
-    query = Sale.query
+    query = Sale.query.options(
+        joinedload(Sale.items).joinedload(SaleItem.product),
+        joinedload(Sale.user),
+        joinedload(Sale.customer)
+    )
     
     if product_search:
         query = query.join(SaleItem).join(Product).filter(
@@ -456,15 +460,15 @@ def sales_report():
         )
 
     if start_date:
-        start_date = datetime.strptime(start_date, '%Y-%m-%d')
-        query = query.filter(Sale.sale_date >= start_date)
+        start_date_obj = datetime.strptime(start_date, '%Y-%m-%d')
+        query = query.filter(Sale.sale_date >= start_date_obj)
     
     if end_date:
-        end_date = datetime.strptime(end_date, '%Y-%m-%d') + timedelta(days=1)
-        query = query.filter(Sale.sale_date < end_date)
+        end_date_obj = datetime.strptime(end_date, '%Y-%m-%d') + timedelta(days=1)
+        query = query.filter(Sale.sale_date < end_date_obj)
     
     if payment_method:
-        query = query.filter_by(payment_method=payment_method)
+        query = query.filter(Sale.payment_method == payment_method)
     
     # Get sales data
     sales = query.order_by(Sale.sale_date.desc()).limit(50).all()
@@ -475,18 +479,27 @@ def sales_report():
     average_sale = total_sales / total_transactions if total_transactions > 0 else 0
     
     # Sales by payment method
-    sales_by_method = db.session.query(
+    sales_by_method_query = db.session.query(
         Sale.payment_method,
         func.count(Sale.id).label('count'),
         func.sum(Sale.total_amount).label('total')
-    ).group_by(Sale.payment_method).all()
+    )
+
+    if start_date:
+        sales_by_method_query = sales_by_method_query.filter(Sale.sale_date >= datetime.strptime(start_date, '%Y-%m-%d'))
+    if end_date:
+        sales_by_method_query = sales_by_method_query.filter(Sale.sale_date < (datetime.strptime(end_date, '%Y-%m-%d') + timedelta(days=1)))
+    if payment_method:
+        sales_by_method_query = sales_by_method_query.filter(Sale.payment_method == payment_method)
+
+    sales_by_method = sales_by_method_query.group_by(Sale.payment_method).all()
     
     # Prepare data for chart
-    payment_method_labels = [method[0].capitalize() for method in sales_by_method]
-    payment_method_data = [float(method[2]) for method in sales_by_method]
+    payment_method_labels = [method[0].capitalize() for method in sales_by_method] if sales_by_method else []
+    payment_method_data = [float(method[2]) for method in sales_by_method] if sales_by_method else []
     
     return render_template('sales_report.html',
-                        products=products,
+                        sales=sales,
                         total_sales=total_sales,
                         total_transactions=total_transactions,
                         average_sale=average_sale,

--- a/templates/sales_report.html
+++ b/templates/sales_report.html
@@ -81,9 +81,10 @@
     </div>
     <div class="card-body">
         <div class="table-responsive">
-            <table class="table table-sm">
+            <table class="table table-sm table-hover">
                 <thead>
                     <tr>
+                        <th></th>
                         <th>Receipt #</th>
                         <th>Date</th>
                         <th>Cashier</th>
@@ -97,7 +98,8 @@
                 </thead>
                 <tbody>
                     {% for sale in sales %}
-                    <tr>
+                    <tr data-bs-toggle="collapse" data-bs-target="#sale-{{ sale.id }}" class="accordion-toggle">
+                        <td><i class="bi bi-chevron-down"></i></td>
                         <td>{{ sale.receipt_number }}</td>
                         <td>{{ sale.sale_date.strftime('%Y-%m-%d %H:%M') }}</td>
                         <td>{{ sale.user.username }}</td>
@@ -110,6 +112,35 @@
                             <a href="{{ url_for('view_receipt', receipt_number=sale.receipt_number) }}" class="btn btn-sm btn-outline-primary">
                                 <i class="bi bi-receipt"></i>
                             </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="10" class="p-0">
+                            <div id="sale-{{ sale.id }}" class="collapse">
+                                <div class="p-3">
+                                    <h6 class="mb-3">Sale Items</h6>
+                                    <table class="table table-sm table-bordered">
+                                        <thead class="table-light">
+                                            <tr>
+                                                <th>Product</th>
+                                                <th class="text-end">Quantity</th>
+                                                <th class="text-end">Unit Price</th>
+                                                <th class="text-end">Total</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for item in sale.items %}
+                                            <tr>
+                                                <td>{{ item.product.name }}</td>
+                                                <td class="text-end">{{ item.quantity }}</td>
+                                                <td class="text-end">KSh {{ "%.2f"|format(item.unit_price) }}</td>
+                                                <td class="text-end">KSh {{ "%.2f"|format(item.total_price) }}</td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
                         </td>
                     </tr>
                     {% endfor %}


### PR DESCRIPTION
This commit fixes several issues with the reporting functionality, with a focus on the sales report.

The sales report was crashing due to a `NameError` in the `sales_report` function. This has been fixed.

The sales report now displays the individual items for each sale, including the product name, quantity, unit price, and total price. This information is displayed in a collapsible section to maintain a clean user interface.

The database query for the sales report has been optimized using `joinedload` to prevent N+1 query issues and improve performance. The query for "sales by payment method" has also been fixed to correctly apply date and payment method filters.

The other reports (`daily`, `employee`, `supplier`) were reviewed, and no critical issues were found.