### PR TITLE
Fix: Sales report print and delete buttons not working

### DIFF
--- a/templates/sales_report.html
+++ b/templates/sales_report.html
@@ -235,7 +235,8 @@
 
         const deleteButtons = document.querySelectorAll('.delete-receipt-btn');
         deleteButtons.forEach(button => {
-            button.addEventListener('click', function() {
+            button.addEventListener('click', function(event) {
+                event.stopPropagation();
                 const receiptNumber = this.dataset.receiptNumber;
                 if (confirm(`Are you sure you want to delete receipt #${receiptNumber}?`)) {
                     const form = document.createElement('form');
@@ -244,6 +245,13 @@
                     document.body.appendChild(form);
                     form.submit();
                 }
+            });
+        });
+
+        const printButtons = document.querySelectorAll('.btn-outline-secondary');
+        printButtons.forEach(button => {
+            button.addEventListener('click', function(event) {
+                event.stopPropagation();
             });
         });
     });


### PR DESCRIPTION
The click events on the print and delete buttons were being intercepted by the accordion toggle on the table row.

This commit adds `event.stopPropagation()` to the button click handlers to prevent the event from bubbling up to the table row, allowing the buttons to function correctly.