### PR TITLE
Fix: Use fetch API for delete receipt

### DIFF
--- a/app.py
+++ b/app.py
@@ -766,7 +766,7 @@ def print_receipt(receipt_number):
     sale = Sale.query.filter_by(receipt_number=receipt_number).first_or_404()
     return render_template('receipt_print.html', sale=sale)
 
-@app.route('/receipt/<receipt_number>/delete', methods=['POST'])
+@app.route('/receipt/<receipt_number>/delete', methods=['DELETE'])
 @login_required(roles=['admin'])
 def delete_receipt(receipt_number):
     app.logger.info(f"Attempting to delete receipt: {receipt_number}")
@@ -781,7 +781,7 @@ def delete_receipt(receipt_number):
 
     flash(f'Receipt #{receipt_number} deleted successfully.', 'success')
     app.logger.info(f"Successfully deleted receipt: {receipt_number}")
-    return redirect(url_for('sales_report'))
+    return jsonify({'success': True})
 @app.route('/purchase_orders/<int:order_id>/receive', methods=['POST'])
 @login_required(roles=['manager'])
 def receive_purchase_order(order_id):

--- a/templates/sales_report.html
+++ b/templates/sales_report.html
@@ -238,11 +238,21 @@
             button.addEventListener('click', function() {
                 const receiptNumber = this.dataset.receiptNumber;
                 if (confirm(`Are you sure you want to delete receipt #${receiptNumber}?`)) {
-                    const form = document.createElement('form');
-                    form.method = 'POST';
-                    form.action = `/receipt/${receiptNumber}/delete`;
-                    document.body.appendChild(form);
-                    form.submit();
+                    fetch(`/receipt/${receiptNumber}/delete`, {
+                        method: 'DELETE',
+                    })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.success) {
+                            window.location.reload();
+                        } else {
+                            alert('Failed to delete receipt.');
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        alert('An error occurred while deleting the receipt.');
+                    });
                 }
             });
         });


### PR DESCRIPTION
The previous implementation was using a form submission to delete the receipt, which was not working as expected.

This commit updates the JavaScript to use the `fetch` API to send a `DELETE` request to the server. The `delete_receipt` route has also been updated to accept `DELETE` requests.