### PR TITLE
Fix: Incorrect purchase price calculation in inventory management

### DIFF
--- a/app.py
+++ b/app.py
@@ -900,7 +900,7 @@ def inventory_management():
     ).scalar() or 0
 
     total_purchase_amount = db.session.query(
-        func.sum(InventoryMovement.total_amount)
+        func.sum(InventoryMovement.quantity * InventoryMovement.unit_price)
     ).join(
         Product
     ).filter(


### PR DESCRIPTION
The inventory management page was not correctly calculating the total purchase amount. It was summing the `total_amount` column from the `InventoryMovement` table, which was not always set for purchase movements.

This commit updates the `inventory_management` function to calculate the total purchase amount by multiplying the `quantity` by the `unit_price` for each `InventoryMovement` of type 'purchase'. This ensures that the calculation is correct even if the `total_amount` is not set.