### PR TITLE
I've fixed a missing import for `generate_password_hash`. The `genera…

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import string
 from config import Config
 from sqlalchemy import func, or_
 from flask_migrate import Migrate
+from werkzeug.security import generate_password_hash
 
 app = Flask(__name__)
 application = app  


### PR DESCRIPTION
…te_password_hash` function was not imported, causing an error when you were resetting the password. I've now added the import statement for `generate_password_hash` from `werkzeug.security`.