### PR TITLE
Fix: Use pbkdf2:sha256 for password hashing

### DIFF
--- a/models.py
+++ b/models.py
@@ -27,7 +27,7 @@ class User(db.Model):
     location = db.relationship('Location', backref='users')
 
     def set_password(self, password):
-        self.password_hash = generate_password_hash(password)
+        self.password_hash = generate_password_hash(password, method='pbkdf2:sha256')
 
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)


### PR DESCRIPTION
The default hashing algorithm, scrypt, was not supported on the server, causing a `ValueError`.

This commit updates the `set_password` method in the `User` model to use the `pbkdf2:sha256` hashing method, which is more widely supported.