### PR TITLE
Fix dashboard chart error due to outdated configuration

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -116,30 +116,32 @@
         },
         options: {
             scales: {
-                xAxes: [{
+                x: {
                     time: {
-                        unit: 'date'
+                        unit: 'day'
                     },
-                    gridLines: {
+                    grid: {
                         display: false
                     },
                     ticks: {
                         maxTicksLimit: 7
                     }
-                }],
-                yAxes: [{
+                },
+                y: {
                     ticks: {
                         min: 0,
                         max: {{ max_sales }},
                         maxTicksLimit: 5
                     },
-                    gridLines: {
+                    grid: {
                         color: "rgba(0, 0, 0, .125)",
                     }
-                }],
+                }
             },
-            legend: {
-                display: false
+            plugins: {
+                legend: {
+                    display: false
+                }
             }
         }
     });


### PR DESCRIPTION
The dashboard chart was not displaying due to a JavaScript error: "Invalid scale configuration for scale: xAxes".

This error was caused by using an outdated Chart.js v2 configuration syntax with a newer version of the Chart.js library loaded from the CDN.

Updated the chart configuration in `templates/dashboard.html` to use the modern Chart.js v3+ API, replacing `xAxes`/`yAxes` with `x`/`y` scales and adjusting other options accordingly. This resolves the error and allows the chart to render correctly.