### PR TITLE
Robust dynamic DigiTax registration and robust pagination lookup

### DIFF
--- a/app.py
+++ b/app.py
@@ -2074,6 +2074,8 @@ def etims_sync_products():
             success_count += 1
         else:
             fail_count += 1
+            app.logger.error(f"Product {product.name} sync failed: {result.get('message')}")
+            flash(f"Failed to sync {product.name}: {result.get('message')}", "danger")
 
     db.session.commit()
 

--- a/etims_service.py
+++ b/etims_service.py
@@ -206,7 +206,7 @@ class ETIMSService:
                 headers = cls.get_headers(config)
                 page = 1
                 found = False
-                while page <= 5:
+                while page <= 10:
                     r_list = requests.get(f"{config.etims_url}/items?page={page}&page_size=100", headers=headers, timeout=10)
                     if r_list.status_code == 200:
                         body_list = r_list.json()
@@ -221,9 +221,7 @@ class ETIMSService:
                                 break
                         if found:
                             break
-                        # Check pagination to see if there are more pages
-                        pagination = body_list.get("pagination", {})
-                        if page >= pagination.get("total_pages", 1):
+                        if len(data_list) < 100:
                             break
                         page += 1
                     else:


### PR DESCRIPTION
Modify register_product to safely search up to 10 pages of the DigiTax item list to prevent barcode duplication errors and ensure existing products are fully matched. Remove dependence on total_pages key, checking data length instead. Add error flashing to the product synchronization route to simplify debugging.